### PR TITLE
Added ASR API URL as default argument

### DIFF
--- a/spokestack/asr/cloud_client.py
+++ b/spokestack/asr/cloud_client.py
@@ -16,9 +16,9 @@ class CloudClient:
     """ Spokestack client for cloud based speech to text
 
         Args:
-            socket_url (str): url for socket connection
             key_id (str): identity from spokestack api credentials
             key_secret (str): secret key from spokestack api credentials
+            socket_url (str): url for socket connection
             audio_format (str): format of input audio
             sample_rate (int): audio sample rate (kHz)
             language (str): language for recognition
@@ -28,9 +28,9 @@ class CloudClient:
 
     def __init__(
         self,
-        socket_url: str,
         key_id: str,
         key_secret: str,
+        socket_url: str = "wss://api.spokestack.io",
         audio_format: str = "PCM16LE",
         sample_rate: int = 16000,
         language: str = "en",


### PR DESCRIPTION
This change makes the spokestack ASR URL the default argument to the cloud client which mirrors the TTS configuration that came up during feedback.