### PR TITLE
Pass explicit args to cloud speech client

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="spokestack",
-    version="0.0.3",
+    version="0.0.5",
     author="Spokestack",
     author_email="support@spokestack.io",
     description="Spokestack Library for Python",

--- a/spokestack/asr/speech_recognizer.py
+++ b/spokestack/asr/speech_recognizer.py
@@ -32,9 +32,9 @@ class CloudSpeechRecognizer:
     ) -> None:
 
         self._client: CloudClient = CloudClient(
-            spokestack_id,
-            spokestack_secret,
-            language,
+            key_id=spokestack_id,
+            key_secret=spokestack_secret,
+            language=language,
             sample_rate=sample_rate,
             idle_timeout=int(idle_timeout / frame_width),
         )


### PR DESCRIPTION
The change yesterday in `CloudClient` made it necessary to pass these as keywords and not positional. 