### PR TITLE
Add Dependencies to Publish Script

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -16,11 +16,11 @@ jobs:
             - name: Set up Python
               uses: actions/setup-python@v2
               with:
-                  python-version: "3.x"
+                  python-version: "3.8"
             - name: Install dependencies
               run: |
                   python -m pip install --upgrade pip
-                  pip install setuptools wheel twine
+                  pip install setuptools numpy Cython wheel twine
             - name: Build and publish
               env:
                   TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="spokestack",
-    version="0.0.15",
+    version="0.0.16",
     author="Spokestack",
     author_email="support@spokestack.io",
     description="Spokestack Library for Python",


### PR DESCRIPTION
This adds numpy and Cython to the publish workflow. The on-release failed because numpy wasn't installed.