### PR TITLE
Remove setting the input source to None in cleanup.

### DIFF
--- a/spokestack/pipeline.py
+++ b/spokestack/pipeline.py
@@ -83,7 +83,6 @@ class SpeechPipeline:
 
         self._stages.clear()
         self._input_source.close()
-        self._input_source = None
         self._context.reset()
 
     def event(self, function: Any = None, name: Union[str, None] = None) -> Any:

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -70,7 +70,6 @@ def test_cleanup():
 
     pipeline.cleanup()
     assert not pipeline._stages
-    assert not pipeline._input_source
 
 
 def test_events():


### PR DESCRIPTION
We still want to call clean up in `run`, but if we set the input source to `None` the pipeline can't be started again.