### PR TITLE
Add pyproject.toml to ensure C/Cython files are included when building wheels for distribution. 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel", "Cython"]


### PR DESCRIPTION
This change fixes an issue that prevented C files from being included with the Linux wheels. This is [documented](https://cython.readthedocs.io/en/latest/src/userguide/source_files_and_compilation.html#basic-setup-py), but I was under the impression that `pyproject.toml` and `setup.cfg` were either/or. It looks like until everything supports `pyproject.toml` [both](https://github.com/pypa/build) are necessary.