### PR TITLE
Allow Pipeline to Restart After Stopped

### DIFF
--- a/spokestack/pipeline.py
+++ b/spokestack/pipeline.py
@@ -32,6 +32,12 @@ class SpeechPipeline:
         """ Closes the running pipeline """
         self.stop()
 
+        for stage in self._stages:
+            stage.close()
+
+        self._stages.clear()
+        self._input_source.close()
+
     def activate(self) -> None:
         """ Activates the pipeline """
         self._context.is_active = True
@@ -50,6 +56,7 @@ class SpeechPipeline:
         """ Halts the pipeline """
         self._is_running = False
         self._input_source.stop()
+        self._context.reset()
 
     def pause(self) -> None:
         """ Stops audio input until resume is called """
@@ -68,22 +75,12 @@ class SpeechPipeline:
 
         while self._is_running:
             self.step()
-        self.cleanup()
 
     def step(self) -> None:
         """ Process a single frame with the pipeline """
         self._context.event("step")
         if not self._is_paused:
             self._dispatch()
-
-    def cleanup(self) -> None:
-        """ Resets all attributes to default configuration """
-        for stage in self._stages:
-            stage.close()
-
-        self._stages.clear()
-        self._input_source.close()
-        self._context.reset()
 
     def event(self, function: Any = None, name: Union[str, None] = None) -> Any:
         """Registers an event handler

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -54,24 +54,6 @@ def test_activate_deactivate():
     assert not pipeline.context.is_active
 
 
-def test_cleanup():
-    stages = [
-        mock.MagicMock(),
-        mock.MagicMock(),
-        mock.MagicMock(),
-    ]
-    pipeline = SpeechPipeline(mock.MagicMock(), stages=stages)
-
-    pipeline.start()
-    assert pipeline.is_running
-
-    pipeline.stop()
-    assert not pipeline.is_running
-
-    pipeline.cleanup()
-    assert not pipeline._stages
-
-
 def test_events():
     stages = [
         mock.MagicMock(),


### PR DESCRIPTION
Initially, the pipeline set the input source to None on a call to stop. This blocked the ability to start again without creating a new pipeline instance. There are certain situations where the user may want to halt the pipeline for a period longer than a pause, but stil be able to start again without restarting the main application.