### PR TITLE
Fix Numpy ValueError Issue.

### DIFF
--- a/.github/workflows/github-deploy.yml
+++ b/.github/workflows/github-deploy.yml
@@ -31,6 +31,8 @@ jobs:
 
       - name: Build wheels
         uses: joerick/cibuildwheel@v1.10.0
+        env:
+          CIBW_SKIP: cp39-macosx_x86_64
 
       - uses: actions/upload-artifact@v2
         with:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-recursive-include spokestack/extensions/portaudio
+recursive-include spokestack/extensions/portaudio/ *

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,3 @@
 [build-system]
-requires = ["setuptools", "wheel", "numpy", "Cython"]
+requires = ["setuptools", "wheel", "numpy==1.19.2", "Cython>=0.29.22"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -9,13 +9,13 @@ from setuptools.command.build_py import build_py
 try:
     from numpy import get_include
 except ImportError:
-    subprocess.check_call([sys.executable, "-m", "pip", "install", "numpy"])
+    subprocess.check_call([sys.executable, "-m", "pip", "install", "numpy==1.19.2"])
     from numpy import get_include
 
 try:
     from Cython.Build import cythonize
 except ImportError:
-    subprocess.check_call([sys.executable, "-m", "pip", "install", "Cython"])
+    subprocess.check_call([sys.executable, "-m", "pip", "install", "Cython==0.29.22"])
     from Cython.Build import cythonize
 
 
@@ -124,10 +124,10 @@ setup(
         "Operating System :: OS Independent",
     ],
     python_requires=">=3.8",
-    setup_requires=["setuptools", "wheel", "numpy", "Cython"],
+    setup_requires=["setuptools", "wheel", "numpy==1.19.2", "Cython>=0.29.22"],
     install_requires=[
-        "numpy",
-        "Cython",
+        "numpy==1.19.2",
+        "Cython>=0.29.22",
         "websocket_client",
         "tokenizers",
         "requests",


### PR DESCRIPTION
This was an issue with a NumPy version mismatch during the distribution build process. Based on my testing, pinning the NumPy version to `1.19.2` fixes this issue. It does look like `1.20.0` has major changes, so there may be additional things to update when TensorFlow supports that version.