### PR TITLE
Refactor GoogleSpeechRecognizer to support >=3.6

### DIFF
--- a/.github/workflows/github-deploy.yml
+++ b/.github/workflows/github-deploy.yml
@@ -29,10 +29,14 @@ jobs:
         if: runner.os == 'Windows'
         run: choco install vcpython27 -f -y
 
+      - name: Install openblas for macos
+        if: runner.os == 'macOS'
+        run: brew install openblas
+
       - name: Build wheels
         uses: joerick/cibuildwheel@v1.10.0
         env:
-          CIBW_SKIP: cp39-macosx_x86_64
+          CIBW_ENVIRONMENT_MACOS: OPENBLAS="$(brew --prefix openblas)"
 
       - uses: actions/upload-artifact@v2
         with:

--- a/setup.py
+++ b/setup.py
@@ -123,7 +123,7 @@ setup(
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
     ],
-    python_requires=">=3.8",
+    python_requires=">=3.6",
     setup_requires=["setuptools", "wheel", "numpy==1.19.2", "Cython>=0.29.22"],
     install_requires=[
         "numpy==1.19.2",

--- a/spokestack/asr/google/speech_recognizer.py
+++ b/spokestack/asr/google/speech_recognizer.py
@@ -107,7 +107,10 @@ class GoogleSpeechRecognizer:
                         _LOG.debug("timeout event")
 
     def _drain(self) -> Generator:
-        while data := self._queue.get():
+        while True:
+            data = self._queue.get()
+            if not data:
+                break
             yield data
 
     def _commit(self) -> None:

--- a/tests/asr/google/test_google_speech_recognizer.py
+++ b/tests/asr/google/test_google_speech_recognizer.py
@@ -4,6 +4,7 @@ This module contains the tests for the GoogleSpeechRecognizer class
 from unittest import mock
 
 import numpy as np
+import pytest
 
 from spokestack.asr.google.speech_recognizer import GoogleSpeechRecognizer
 from spokestack.context import SpeechContext
@@ -61,3 +62,10 @@ def test_drain(*args):
     recognizer = GoogleSpeechRecognizer(language="en-US", credentials="")
     recognizer._queue.put([audio, audio, audio])
     next(recognizer._drain())
+
+
+@mock.patch("spokestack.asr.google.speech_recognizer.speech")
+@mock.patch("spokestack.asr.google.speech_recognizer.service_account")
+def test_invalid_creds(*args):
+    with pytest.raises(ValueError):
+        _ = GoogleSpeechRecognizer(language="en-US", credentials=1234)


### PR DESCRIPTION
This change enables backward compatibility for Python 3.7.