### PR TITLE
Expose TTS profile to clients

### DIFF
--- a/spokestack/tts/manager.py
+++ b/spokestack/tts/manager.py
@@ -20,16 +20,31 @@ class TextToSpeechManager:
         self._client = client
         self._output = output
 
-    def synthesize(self, utterance: str, mode: str, voice: str) -> None:
+    def synthesize(
+        self,
+        utterance: str,
+        mode: str = "text",
+        voice: str = "demo-male",
+        profile: str = "default",
+    ) -> None:
         """Synthesizes the given utterance with the voice and format provided.
+
+        Text can be formatted as plain text (`mode="text"`),
+        SSML (`mode="ssml"`), or Speech Markdown (`mode="markdown"`).
+
+        This method also supports different formats for the synthesized
+        audio via the `profile` argument. The supported profiles and
+        their associated formats are:
 
         Args:
             utterance (str): string that needs to be rendered as speech.
             mode (str): synthesis mode to use with utterance. text, ssml, markdown, etc.
             voice (str): name of the tts voice.
+            profile (str): name of the audio profile used to create the
+                           resulting stream.
 
         """
-        stream = self._client.synthesize(utterance, mode, voice)
+        stream = self._client.synthesize(utterance, mode, voice, profile)
         stream = SequenceIO(stream)
         for frame in MP3Decoder(stream):
             self._output.write(frame)

--- a/tests/tts/test_manager.py
+++ b/tests/tts/test_manager.py
@@ -16,7 +16,7 @@ def test_synthesize():
     with mock.patch("spokestack.tts.manager.MP3Decoder") as patched:
         patched.return_value = np.zeros(160).tobytes()
         manager = TextToSpeechManager(client, output)
-        manager.synthesize(utterance="test utterance", mode="text", voice="demo-male")
+        manager.synthesize(utterance="test utterance")
 
 
 def test_close():

--- a/tests/tts/test_tts_client.py
+++ b/tests/tts/test_tts_client.py
@@ -10,6 +10,18 @@ from requests import Response
 from spokestack.tts.clients.spokestack import TextToSpeechClient, TTSError
 
 
+def test_graphql():
+    client = TextToSpeechClient("", "", "")
+    voice = 'voice'
+    profile = 'test'
+
+    for mode in ['text', 'ssml', 'markdown']:
+        method = f'synthesize{mode[0].upper()}{mode[1:]}'
+        body = client._build_body("test", mode=mode, voice=voice, profile=profile)
+        assert f'{method}(' in body
+        assert profile.upper() in body
+
+
 def test_synthesize_text():
     client = TextToSpeechClient("", "", "")
 
@@ -23,6 +35,8 @@ def test_synthesize_text():
             iter_content=mock_iterable, status_code=200
         )
         response = client.synthesize("test utterance")
+        assert response == test
+        response = client.synthesize("test utterance", profile="alexa")
         assert response == test
 
 


### PR DESCRIPTION
This change allows clients to access the `profile` argument
for the GraphQL synthesis method so that audio formatted for
third-party services can be produced. It also condenses the
GraphQL query creation and adds some documentation for the
new option.

Default values have been added to the manager's `synthesize`
method to support some example code from the readme. The
enclosing GraphQL query has also been changed to include the
platform name.