### PR TITLE
Fix Copyright Year for README and Readthedocs

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ twine upload dist/*
 
 ## License
 
-Copyright 2020 Spokestack, Inc.
+Copyright 2021 Spokestack, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License [here](http://www.apache.org/licenses/LICENSE-2.0)
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -6,6 +6,8 @@
 
 # -- Path setup --------------------------------------------------------------
 
+import datetime
+
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
@@ -21,7 +23,7 @@ autodoc_mock_imports = ["pyaudio", "streamp3", "webrtc", "google", "tflite_runti
 # -- Project information -----------------------------------------------------
 
 project = "spokestack"
-copyright = "2020, Spokestack"
+copyright = f"{datetime.datetime.now().year}, Spokestack"
 author = "Spokestack"
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
I auto-pulled the year for readthedocs, but I'm not sure how to do it for the README.